### PR TITLE
30 feature update dockerbake action to v6

### DIFF
--- a/.github/workflows-template/docker-buildx-bake/docker-buildx-bake-hubdocker-latest.yml
+++ b/.github/workflows-template/docker-buildx-bake/docker-buildx-bake-hubdocker-latest.yml
@@ -117,7 +117,7 @@ jobs:
         name: Rename meta bake definition file
         run: |
           mkdir -p "${{ runner.temp }}/${{ inputs.docker_bake_targets}}"
-          mv "${{ steps.meta.outputs.bake-file }}" "${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json"
+          mv "${{ steps.meta.outputs.bake-file }}" "cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json"
 
       -
         name: Upload meta bake definition
@@ -125,7 +125,7 @@ jobs:
         if: ${{ inputs.push_remote_flag }}
         with:
           name: bake-latest-meta-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.docker_bake_targets }}-${{ env.PLATFORM_PAIR }}
-          path: ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
+          path: cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
           overwrite: true
           if-no-files-found: error
           retention-days: 1
@@ -154,7 +154,7 @@ jobs:
         run: |
           echo "docker_bake_config_file_path: cwd://${{ inputs.docker_bake_config_file_path }}"
           ls -al ${{ runner.temp }}/${{ inputs.docker_bake_targets}}
-          cat ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
+          cat cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
 
       -
         name: Build
@@ -164,7 +164,7 @@ jobs:
         with:
           files: |
             cwd://${{ inputs.docker_bake_config_file_path }}
-            ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
+            cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
           targets: ${{ inputs.docker_bake_targets }}
           no-cache: ${{ inputs.docker-build-no-cache }}
           provenance: false
@@ -262,10 +262,10 @@ jobs:
         name: Create manifest list and push
         working-directory: ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/digests/
         run: |
-          docker buildx imagetools create $(jq -cr '.target."docker-metadata-action".tags | map(select(startswith("${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}")) | "-t " + .) | join(" ")' ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json) \
+          docker buildx imagetools create $(jq -cr '.target."docker-metadata-action".tags | map(select(startswith("${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}")) | "-t " + .) | join(" ")' cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json) \
             $(printf '${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}@sha256:%s ' *)
       -
         name: Inspect image
         run: |
-          tag=$(jq -r '.target."docker-metadata-action".args.DOCKER_META_VERSION' ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json)
+          tag=$(jq -r '.target."docker-metadata-action".args.DOCKER_META_VERSION' cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json)
           docker buildx imagetools inspect ${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}:${tag}

--- a/.github/workflows-template/docker-buildx-bake/docker-buildx-bake-hubdocker-latest.yml
+++ b/.github/workflows-template/docker-buildx-bake/docker-buildx-bake-hubdocker-latest.yml
@@ -150,9 +150,16 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       -
+        name: check build files
+        run: |
+          echo "docker_bake_config_file_path: ${{ inputs.docker_bake_config_file_path }}"
+          ls -al ${{ runner.temp }}/${{ inputs.docker_bake_targets}}
+          cat ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
+
+      -
         name: Build
         id: bake
-        uses: docker/bake-action@v5
+        uses: docker/bake-action@v6
         timeout-minutes: ${{ inputs.docker-build-timeout-minutes }} # default 360
         with:
           files: |

--- a/.github/workflows-template/docker-buildx-bake/docker-buildx-bake-hubdocker-latest.yml
+++ b/.github/workflows-template/docker-buildx-bake/docker-buildx-bake-hubdocker-latest.yml
@@ -117,7 +117,7 @@ jobs:
         name: Rename meta bake definition file
         run: |
           mkdir -p "${{ runner.temp }}/${{ inputs.docker_bake_targets}}"
-          mv "${{ steps.meta.outputs.bake-file }}" "cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json"
+          mv "${{ steps.meta.outputs.bake-file }}" "${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json"
 
       -
         name: Upload meta bake definition
@@ -125,7 +125,7 @@ jobs:
         if: ${{ inputs.push_remote_flag }}
         with:
           name: bake-latest-meta-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.docker_bake_targets }}-${{ env.PLATFORM_PAIR }}
-          path: cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
+          path: ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
           overwrite: true
           if-no-files-found: error
           retention-days: 1
@@ -152,9 +152,9 @@ jobs:
       -
         name: check build files
         run: |
-          echo "docker_bake_config_file_path: cwd://${{ inputs.docker_bake_config_file_path }}"
+          echo "docker_bake_config_file_path: ${{ inputs.docker_bake_config_file_path }}"
           ls -al ${{ runner.temp }}/${{ inputs.docker_bake_targets}}
-          cat cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
+          cat ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
 
       -
         name: Build
@@ -262,10 +262,10 @@ jobs:
         name: Create manifest list and push
         working-directory: ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/digests/
         run: |
-          docker buildx imagetools create $(jq -cr '.target."docker-metadata-action".tags | map(select(startswith("${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}")) | "-t " + .) | join(" ")' cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json) \
+          docker buildx imagetools create $(jq -cr '.target."docker-metadata-action".tags | map(select(startswith("${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}")) | "-t " + .) | join(" ")' ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json) \
             $(printf '${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}@sha256:%s ' *)
       -
         name: Inspect image
         run: |
-          tag=$(jq -r '.target."docker-metadata-action".args.DOCKER_META_VERSION' cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json)
+          tag=$(jq -r '.target."docker-metadata-action".args.DOCKER_META_VERSION' ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json)
           docker buildx imagetools inspect ${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}:${tag}

--- a/.github/workflows-template/docker-buildx-bake/docker-buildx-bake-hubdocker-latest.yml
+++ b/.github/workflows-template/docker-buildx-bake/docker-buildx-bake-hubdocker-latest.yml
@@ -152,7 +152,7 @@ jobs:
       -
         name: check build files
         run: |
-          echo "docker_bake_config_file_path: ${{ inputs.docker_bake_config_file_path }}"
+          echo "docker_bake_config_file_path: cwd://${{ inputs.docker_bake_config_file_path }}"
           ls -al ${{ runner.temp }}/${{ inputs.docker_bake_targets}}
           cat ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
 
@@ -163,7 +163,7 @@ jobs:
         timeout-minutes: ${{ inputs.docker-build-timeout-minutes }} # default 360
         with:
           files: |
-            ${{ inputs.docker_bake_config_file_path }}
+            cwd://${{ inputs.docker_bake_config_file_path }}
             ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
           targets: ${{ inputs.docker_bake_targets }}
           no-cache: ${{ inputs.docker-build-no-cache }}

--- a/.github/workflows-template/docker-buildx-bake/docker-buildx-bake-hubdocker-tag.yml
+++ b/.github/workflows-template/docker-buildx-bake/docker-buildx-bake-hubdocker-tag.yml
@@ -116,7 +116,7 @@ jobs:
         name: Rename meta bake definition file
         run: |
           mkdir -p "${{ runner.temp }}/${{ inputs.docker_bake_targets}}"
-          mv "${{ steps.meta.outputs.bake-file }}" "cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json"
+          mv "${{ steps.meta.outputs.bake-file }}" "${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json"
 
       -
         name: Upload meta bake definition
@@ -124,7 +124,7 @@ jobs:
         if: ${{ inputs.push_remote_flag }}
         with:
           name: bake-tag-meta-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.docker_bake_targets }}-${{ env.PLATFORM_PAIR }}
-          path: cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
+          path: ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
           overwrite: true
           if-no-files-found: error
           retention-days: 1
@@ -151,9 +151,9 @@ jobs:
       -
         name: check build files
         run: |
-          echo "docker_bake_config_file_path: cwd://${{ inputs.docker_bake_config_file_path }}"
+          echo "docker_bake_config_file_path: ${{ inputs.docker_bake_config_file_path }}"
           ls -al ${{ runner.temp }}/${{ inputs.docker_bake_targets}}
-          cat cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
+          cat ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
 
       -
         name: Build
@@ -261,10 +261,10 @@ jobs:
         name: Create manifest list and push
         working-directory: ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/digests/
         run: |
-          docker buildx imagetools create $(jq -cr '.target."docker-metadata-action".tags | map(select(startswith("${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}")) | "-t " + .) | join(" ")' cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json) \
+          docker buildx imagetools create $(jq -cr '.target."docker-metadata-action".tags | map(select(startswith("${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}")) | "-t " + .) | join(" ")' ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json) \
             $(printf '${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}@sha256:%s ' *)
       -
         name: Inspect image
         run: |
-          tag=$(jq -r '.target."docker-metadata-action".args.DOCKER_META_VERSION' cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json)
+          tag=$(jq -r '.target."docker-metadata-action".args.DOCKER_META_VERSION' ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json)
           docker buildx imagetools inspect ${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}:${tag}

--- a/.github/workflows-template/docker-buildx-bake/docker-buildx-bake-hubdocker-tag.yml
+++ b/.github/workflows-template/docker-buildx-bake/docker-buildx-bake-hubdocker-tag.yml
@@ -151,7 +151,7 @@ jobs:
       -
         name: check build files
         run: |
-          echo "docker_bake_config_file_path: ${{ inputs.docker_bake_config_file_path }}"
+          echo "docker_bake_config_file_path: cwd://${{ inputs.docker_bake_config_file_path }}"
           ls -al ${{ runner.temp }}/${{ inputs.docker_bake_targets}}
           cat ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
 
@@ -162,7 +162,7 @@ jobs:
         timeout-minutes: ${{ inputs.docker-build-timeout-minutes }} # default 360
         with:
           files: |
-            ${{ inputs.docker_bake_config_file_path }}
+            cwd://${{ inputs.docker_bake_config_file_path }}
             ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
           targets: ${{ inputs.docker_bake_targets }}
           no-cache: ${{ inputs.docker-build-no-cache }}

--- a/.github/workflows-template/docker-buildx-bake/docker-buildx-bake-hubdocker-tag.yml
+++ b/.github/workflows-template/docker-buildx-bake/docker-buildx-bake-hubdocker-tag.yml
@@ -149,9 +149,16 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       -
+        name: check build files
+        run: |
+          echo "docker_bake_config_file_path: ${{ inputs.docker_bake_config_file_path }}"
+          ls -al ${{ runner.temp }}/${{ inputs.docker_bake_targets}}
+          cat ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
+
+      -
         name: Build
         id: bake
-        uses: docker/bake-action@v5
+        uses: docker/bake-action@v6
         timeout-minutes: ${{ inputs.docker-build-timeout-minutes }} # default 360
         with:
           files: |

--- a/.github/workflows-template/docker-buildx-bake/docker-buildx-bake-hubdocker-tag.yml
+++ b/.github/workflows-template/docker-buildx-bake/docker-buildx-bake-hubdocker-tag.yml
@@ -116,7 +116,7 @@ jobs:
         name: Rename meta bake definition file
         run: |
           mkdir -p "${{ runner.temp }}/${{ inputs.docker_bake_targets}}"
-          mv "${{ steps.meta.outputs.bake-file }}" "${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json"
+          mv "${{ steps.meta.outputs.bake-file }}" "cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json"
 
       -
         name: Upload meta bake definition
@@ -124,7 +124,7 @@ jobs:
         if: ${{ inputs.push_remote_flag }}
         with:
           name: bake-tag-meta-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.docker_bake_targets }}-${{ env.PLATFORM_PAIR }}
-          path: ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
+          path: cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
           overwrite: true
           if-no-files-found: error
           retention-days: 1
@@ -153,7 +153,7 @@ jobs:
         run: |
           echo "docker_bake_config_file_path: cwd://${{ inputs.docker_bake_config_file_path }}"
           ls -al ${{ runner.temp }}/${{ inputs.docker_bake_targets}}
-          cat ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
+          cat cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
 
       -
         name: Build
@@ -163,7 +163,7 @@ jobs:
         with:
           files: |
             cwd://${{ inputs.docker_bake_config_file_path }}
-            ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
+            cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
           targets: ${{ inputs.docker_bake_targets }}
           no-cache: ${{ inputs.docker-build-no-cache }}
           provenance: false
@@ -261,10 +261,10 @@ jobs:
         name: Create manifest list and push
         working-directory: ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/digests/
         run: |
-          docker buildx imagetools create $(jq -cr '.target."docker-metadata-action".tags | map(select(startswith("${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}")) | "-t " + .) | join(" ")' ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json) \
+          docker buildx imagetools create $(jq -cr '.target."docker-metadata-action".tags | map(select(startswith("${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}")) | "-t " + .) | join(" ")' cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json) \
             $(printf '${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}@sha256:%s ' *)
       -
         name: Inspect image
         run: |
-          tag=$(jq -r '.target."docker-metadata-action".args.DOCKER_META_VERSION' ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json)
+          tag=$(jq -r '.target."docker-metadata-action".args.DOCKER_META_VERSION' cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json)
           docker buildx imagetools inspect ${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}:${tag}

--- a/.github/workflows-template/docker-buildx-bake/docker-buildx-bake-multi-latest.yml
+++ b/.github/workflows-template/docker-buildx-bake/docker-buildx-bake-multi-latest.yml
@@ -167,7 +167,7 @@ jobs:
       -
         name: check build files
         run: |
-          echo "docker_bake_config_file_path: ${{ inputs.docker_bake_config_file_path }}"
+          echo "docker_bake_config_file_path: cwd://${{ inputs.docker_bake_config_file_path }}"
           ls -al ${{ runner.temp }}/${{ inputs.docker_bake_targets}}
           cat ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
 
@@ -178,7 +178,7 @@ jobs:
         timeout-minutes: ${{ inputs.docker-build-timeout-minutes }} # default 360
         with:
           files: |
-            ${{ inputs.docker_bake_config_file_path }}
+            cwd://${{ inputs.docker_bake_config_file_path }}
             ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
           targets: ${{ inputs.docker_bake_targets }}
           no-cache: ${{ inputs.docker-build-no-cache }}

--- a/.github/workflows-template/docker-buildx-bake/docker-buildx-bake-multi-latest.yml
+++ b/.github/workflows-template/docker-buildx-bake/docker-buildx-bake-multi-latest.yml
@@ -123,7 +123,7 @@ jobs:
         name: Rename meta bake definition file
         run: |
           mkdir -p "${{ runner.temp }}/${{ inputs.docker_bake_targets}}"
-          mv "${{ steps.meta.outputs.bake-file }}" "cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json"
+          mv "${{ steps.meta.outputs.bake-file }}" "${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json"
 
       -
         name: Upload meta bake definition
@@ -131,7 +131,7 @@ jobs:
         if: ${{ inputs.push_remote_flag }}
         with:
           name: bake-latest-meta-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.docker_bake_targets }}-${{ env.PLATFORM_PAIR }}
-          path: cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
+          path: ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
           overwrite: true
           if-no-files-found: error
           retention-days: 1
@@ -167,9 +167,9 @@ jobs:
       -
         name: check build files
         run: |
-          echo "docker_bake_config_file_path: cwd://${{ inputs.docker_bake_config_file_path }}"
+          echo "docker_bake_config_file_path: ${{ inputs.docker_bake_config_file_path }}"
           ls -al ${{ runner.temp }}/${{ inputs.docker_bake_targets}}
-          cat cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
+          cat ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
 
       -
         name: Build
@@ -285,13 +285,13 @@ jobs:
         name: Create manifest list and push
         working-directory: ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/digests/
         run: |
-          docker buildx imagetools create $(jq -cr '.target."docker-metadata-action".tags | map(select(startswith("${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}")) | "-t " + .) | join(" ")' cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json) \
+          docker buildx imagetools create $(jq -cr '.target."docker-metadata-action".tags | map(select(startswith("${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}")) | "-t " + .) | join(" ")' ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json) \
             $(printf '${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}@sha256:%s ' *)
-          docker buildx imagetools create $(jq -cr '.target."docker-metadata-action".tags | map(select(startswith("ghcr.io/${{ inputs.ghcr_package_owner_name }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}")) | "-t " + .) | join(" ")' cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json) \
+          docker buildx imagetools create $(jq -cr '.target."docker-metadata-action".tags | map(select(startswith("ghcr.io/${{ inputs.ghcr_package_owner_name }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}")) | "-t " + .) | join(" ")' ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json) \
             $(printf 'ghcr.io/${{ inputs.ghcr_package_owner_name }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}@sha256:%s ' *)
       -
         name: Inspect image
         run: |
-          tag=$(jq -r '.target."docker-metadata-action".args.DOCKER_META_VERSION' cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json)
+          tag=$(jq -r '.target."docker-metadata-action".args.DOCKER_META_VERSION' ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json)
           docker buildx imagetools inspect ${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}:${tag}
           docker buildx imagetools inspect ghcr.io/${{ inputs.ghcr_package_owner_name }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}:${tag}

--- a/.github/workflows-template/docker-buildx-bake/docker-buildx-bake-multi-latest.yml
+++ b/.github/workflows-template/docker-buildx-bake/docker-buildx-bake-multi-latest.yml
@@ -123,7 +123,7 @@ jobs:
         name: Rename meta bake definition file
         run: |
           mkdir -p "${{ runner.temp }}/${{ inputs.docker_bake_targets}}"
-          mv "${{ steps.meta.outputs.bake-file }}" "${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json"
+          mv "${{ steps.meta.outputs.bake-file }}" "cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json"
 
       -
         name: Upload meta bake definition
@@ -131,7 +131,7 @@ jobs:
         if: ${{ inputs.push_remote_flag }}
         with:
           name: bake-latest-meta-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.docker_bake_targets }}-${{ env.PLATFORM_PAIR }}
-          path: ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
+          path: cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
           overwrite: true
           if-no-files-found: error
           retention-days: 1
@@ -169,7 +169,7 @@ jobs:
         run: |
           echo "docker_bake_config_file_path: cwd://${{ inputs.docker_bake_config_file_path }}"
           ls -al ${{ runner.temp }}/${{ inputs.docker_bake_targets}}
-          cat ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
+          cat cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
 
       -
         name: Build
@@ -179,7 +179,7 @@ jobs:
         with:
           files: |
             cwd://${{ inputs.docker_bake_config_file_path }}
-            ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
+            cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
           targets: ${{ inputs.docker_bake_targets }}
           no-cache: ${{ inputs.docker-build-no-cache }}
           provenance: false
@@ -285,13 +285,13 @@ jobs:
         name: Create manifest list and push
         working-directory: ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/digests/
         run: |
-          docker buildx imagetools create $(jq -cr '.target."docker-metadata-action".tags | map(select(startswith("${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}")) | "-t " + .) | join(" ")' ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json) \
+          docker buildx imagetools create $(jq -cr '.target."docker-metadata-action".tags | map(select(startswith("${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}")) | "-t " + .) | join(" ")' cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json) \
             $(printf '${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}@sha256:%s ' *)
-          docker buildx imagetools create $(jq -cr '.target."docker-metadata-action".tags | map(select(startswith("ghcr.io/${{ inputs.ghcr_package_owner_name }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}")) | "-t " + .) | join(" ")' ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json) \
+          docker buildx imagetools create $(jq -cr '.target."docker-metadata-action".tags | map(select(startswith("ghcr.io/${{ inputs.ghcr_package_owner_name }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}")) | "-t " + .) | join(" ")' cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json) \
             $(printf 'ghcr.io/${{ inputs.ghcr_package_owner_name }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}@sha256:%s ' *)
       -
         name: Inspect image
         run: |
-          tag=$(jq -r '.target."docker-metadata-action".args.DOCKER_META_VERSION' ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json)
+          tag=$(jq -r '.target."docker-metadata-action".args.DOCKER_META_VERSION' cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json)
           docker buildx imagetools inspect ${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}:${tag}
           docker buildx imagetools inspect ghcr.io/${{ inputs.ghcr_package_owner_name }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}:${tag}

--- a/.github/workflows-template/docker-buildx-bake/docker-buildx-bake-multi-latest.yml
+++ b/.github/workflows-template/docker-buildx-bake/docker-buildx-bake-multi-latest.yml
@@ -165,9 +165,16 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       -
+        name: check build files
+        run: |
+          echo "docker_bake_config_file_path: ${{ inputs.docker_bake_config_file_path }}"
+          ls -al ${{ runner.temp }}/${{ inputs.docker_bake_targets}}
+          cat ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
+
+      -
         name: Build
         id: bake
-        uses: docker/bake-action@v5
+        uses: docker/bake-action@v6
         timeout-minutes: ${{ inputs.docker-build-timeout-minutes }} # default 360
         with:
           files: |

--- a/.github/workflows-template/docker-buildx-bake/docker-buildx-bake-multi-tag.yml
+++ b/.github/workflows-template/docker-buildx-bake/docker-buildx-bake-multi-tag.yml
@@ -121,7 +121,7 @@ jobs:
         name: Rename meta bake definition file
         run: |
           mkdir -p "${{ runner.temp }}/${{ inputs.docker_bake_targets}}"
-          mv "${{ steps.meta.outputs.bake-file }}" "${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json"
+          mv "${{ steps.meta.outputs.bake-file }}" "cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json"
 
       -
         name: Upload meta bake definition
@@ -129,7 +129,7 @@ jobs:
         if: ${{ inputs.push_remote_flag }}
         with:
           name: bake-tag-meta-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.docker_bake_targets }}-${{ env.PLATFORM_PAIR }}
-          path: ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
+          path: cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
           overwrite: true
           if-no-files-found: error
           retention-days: 1
@@ -167,7 +167,7 @@ jobs:
         run: |
           echo "docker_bake_config_file_path: cwd://${{ inputs.docker_bake_config_file_path }}"
           ls -al ${{ runner.temp }}/${{ inputs.docker_bake_targets}}
-          cat ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
+          cat cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
 
       -
         name: Build
@@ -177,7 +177,7 @@ jobs:
         with:
           files: |
             cwd://${{ inputs.docker_bake_config_file_path }}
-            ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
+            cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
           targets: ${{ inputs.docker_bake_targets }}
           no-cache: ${{ inputs.docker-build-no-cache }}
           provenance: false
@@ -283,13 +283,13 @@ jobs:
         name: Create manifest list and push
         working-directory: ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/digests/
         run: |
-          docker buildx imagetools create $(jq -cr '.target."docker-metadata-action".tags | map(select(startswith("${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}")) | "-t " + .) | join(" ")' ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json) \
+          docker buildx imagetools create $(jq -cr '.target."docker-metadata-action".tags | map(select(startswith("${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}")) | "-t " + .) | join(" ")' cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json) \
             $(printf '${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}@sha256:%s ' *)
-          docker buildx imagetools create $(jq -cr '.target."docker-metadata-action".tags | map(select(startswith("ghcr.io/${{ inputs.ghcr_package_owner_name }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}")) | "-t " + .) | join(" ")' ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json) \
+          docker buildx imagetools create $(jq -cr '.target."docker-metadata-action".tags | map(select(startswith("ghcr.io/${{ inputs.ghcr_package_owner_name }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}")) | "-t " + .) | join(" ")' cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json) \
             $(printf 'ghcr.io/${{ inputs.ghcr_package_owner_name }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}@sha256:%s ' *)
       -
         name: Inspect image
         run: |
-          tag=$(jq -r '.target."docker-metadata-action".args.DOCKER_META_VERSION' ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json)
+          tag=$(jq -r '.target."docker-metadata-action".args.DOCKER_META_VERSION' cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json)
           docker buildx imagetools inspect ${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}:${tag}
           docker buildx imagetools inspect ghcr.io/${{ inputs.ghcr_package_owner_name }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}:${tag}

--- a/.github/workflows-template/docker-buildx-bake/docker-buildx-bake-multi-tag.yml
+++ b/.github/workflows-template/docker-buildx-bake/docker-buildx-bake-multi-tag.yml
@@ -165,7 +165,7 @@ jobs:
       -
         name: check build files
         run: |
-          echo "docker_bake_config_file_path: ${{ inputs.docker_bake_config_file_path }}"
+          echo "docker_bake_config_file_path: cwd://${{ inputs.docker_bake_config_file_path }}"
           ls -al ${{ runner.temp }}/${{ inputs.docker_bake_targets}}
           cat ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
 
@@ -176,7 +176,7 @@ jobs:
         timeout-minutes: ${{ inputs.docker-build-timeout-minutes }} # default 360
         with:
           files: |
-            ${{ inputs.docker_bake_config_file_path }}
+            cwd://${{ inputs.docker_bake_config_file_path }}
             ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
           targets: ${{ inputs.docker_bake_targets }}
           no-cache: ${{ inputs.docker-build-no-cache }}

--- a/.github/workflows-template/docker-buildx-bake/docker-buildx-bake-multi-tag.yml
+++ b/.github/workflows-template/docker-buildx-bake/docker-buildx-bake-multi-tag.yml
@@ -163,9 +163,16 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       -
+        name: check build files
+        run: |
+          echo "docker_bake_config_file_path: ${{ inputs.docker_bake_config_file_path }}"
+          ls -al ${{ runner.temp }}/${{ inputs.docker_bake_targets}}
+          cat ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
+
+      -
         name: Build
         id: bake
-        uses: docker/bake-action@v5
+        uses: docker/bake-action@v6
         timeout-minutes: ${{ inputs.docker-build-timeout-minutes }} # default 360
         with:
           files: |

--- a/.github/workflows-template/docker-buildx-bake/docker-buildx-bake-multi-tag.yml
+++ b/.github/workflows-template/docker-buildx-bake/docker-buildx-bake-multi-tag.yml
@@ -121,7 +121,7 @@ jobs:
         name: Rename meta bake definition file
         run: |
           mkdir -p "${{ runner.temp }}/${{ inputs.docker_bake_targets}}"
-          mv "${{ steps.meta.outputs.bake-file }}" "cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json"
+          mv "${{ steps.meta.outputs.bake-file }}" "${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json"
 
       -
         name: Upload meta bake definition
@@ -129,7 +129,7 @@ jobs:
         if: ${{ inputs.push_remote_flag }}
         with:
           name: bake-tag-meta-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.docker_bake_targets }}-${{ env.PLATFORM_PAIR }}
-          path: cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
+          path: ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
           overwrite: true
           if-no-files-found: error
           retention-days: 1
@@ -165,9 +165,9 @@ jobs:
       -
         name: check build files
         run: |
-          echo "docker_bake_config_file_path: cwd://${{ inputs.docker_bake_config_file_path }}"
+          echo "docker_bake_config_file_path: ${{ inputs.docker_bake_config_file_path }}"
           ls -al ${{ runner.temp }}/${{ inputs.docker_bake_targets}}
-          cat cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
+          cat ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
 
       -
         name: Build
@@ -283,13 +283,13 @@ jobs:
         name: Create manifest list and push
         working-directory: ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/digests/
         run: |
-          docker buildx imagetools create $(jq -cr '.target."docker-metadata-action".tags | map(select(startswith("${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}")) | "-t " + .) | join(" ")' cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json) \
+          docker buildx imagetools create $(jq -cr '.target."docker-metadata-action".tags | map(select(startswith("${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}")) | "-t " + .) | join(" ")' ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json) \
             $(printf '${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}@sha256:%s ' *)
-          docker buildx imagetools create $(jq -cr '.target."docker-metadata-action".tags | map(select(startswith("ghcr.io/${{ inputs.ghcr_package_owner_name }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}")) | "-t " + .) | join(" ")' cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json) \
+          docker buildx imagetools create $(jq -cr '.target."docker-metadata-action".tags | map(select(startswith("ghcr.io/${{ inputs.ghcr_package_owner_name }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}")) | "-t " + .) | join(" ")' ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json) \
             $(printf 'ghcr.io/${{ inputs.ghcr_package_owner_name }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}@sha256:%s ' *)
       -
         name: Inspect image
         run: |
-          tag=$(jq -r '.target."docker-metadata-action".args.DOCKER_META_VERSION' cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json)
+          tag=$(jq -r '.target."docker-metadata-action".args.DOCKER_META_VERSION' ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json)
           docker buildx imagetools inspect ${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}:${tag}
           docker buildx imagetools inspect ghcr.io/${{ inputs.ghcr_package_owner_name }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}:${tag}

--- a/.github/workflows/docker-buildx-bake-hubdocker-latest.yml
+++ b/.github/workflows/docker-buildx-bake-hubdocker-latest.yml
@@ -152,7 +152,7 @@ jobs:
       -
         name: check build files
         run: |
-          echo "docker_bake_config_file_path: ${{ inputs.docker_bake_config_file_path }}"
+          echo "docker_bake_config_file_path: cwd://${{ inputs.docker_bake_config_file_path }}"
           ls -al ${{ runner.temp }}/${{ inputs.docker_bake_targets}}
           echo "show: ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json"
           cat ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
@@ -164,7 +164,7 @@ jobs:
         timeout-minutes: ${{ inputs.docker-build-timeout-minutes }} # default 360
         with:
           files: |
-            ${{ inputs.docker_bake_config_file_path }}
+            cwd://${{ inputs.docker_bake_config_file_path }}
             ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
           targets: ${{ inputs.docker_bake_targets }}
           no-cache: ${{ inputs.docker-build-no-cache }}

--- a/.github/workflows/docker-buildx-bake-hubdocker-latest.yml
+++ b/.github/workflows/docker-buildx-bake-hubdocker-latest.yml
@@ -117,7 +117,7 @@ jobs:
         name: Rename meta bake definition file
         run: |
           mkdir -p "${{ runner.temp }}/${{ inputs.docker_bake_targets}}"
-          mv "${{ steps.meta.outputs.bake-file }}" "cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json"
+          mv "${{ steps.meta.outputs.bake-file }}" "${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json"
 
       -
         name: Upload meta bake definition
@@ -125,7 +125,7 @@ jobs:
         if: ${{ inputs.push_remote_flag }}
         with:
           name: bake-latest-meta-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.docker_bake_targets }}-${{ env.PLATFORM_PAIR }}
-          path: cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
+          path: ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
           overwrite: true
           if-no-files-found: error
           retention-days: 1
@@ -152,10 +152,10 @@ jobs:
       -
         name: check build files
         run: |
-          echo "docker_bake_config_file_path: cwd://${{ inputs.docker_bake_config_file_path }}"
+          echo "docker_bake_config_file_path: ${{ inputs.docker_bake_config_file_path }}"
           ls -al ${{ runner.temp }}/${{ inputs.docker_bake_targets}}
-          echo "show: cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json"
-          cat cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
+          echo "show: ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json"
+          cat ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
 
       -
         name: Build
@@ -263,10 +263,10 @@ jobs:
         name: Create manifest list and push
         working-directory: ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/digests/
         run: |
-          docker buildx imagetools create $(jq -cr '.target."docker-metadata-action".tags | map(select(startswith("${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}")) | "-t " + .) | join(" ")' cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json) \
+          docker buildx imagetools create $(jq -cr '.target."docker-metadata-action".tags | map(select(startswith("${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}")) | "-t " + .) | join(" ")' ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json) \
             $(printf '${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}@sha256:%s ' *)
       -
         name: Inspect image
         run: |
-          tag=$(jq -r '.target."docker-metadata-action".args.DOCKER_META_VERSION' cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json)
+          tag=$(jq -r '.target."docker-metadata-action".args.DOCKER_META_VERSION' ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json)
           docker buildx imagetools inspect ${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}:${tag}

--- a/.github/workflows/docker-buildx-bake-hubdocker-latest.yml
+++ b/.github/workflows/docker-buildx-bake-hubdocker-latest.yml
@@ -154,6 +154,7 @@ jobs:
         run: |
           echo "docker_bake_config_file_path: ${{ inputs.docker_bake_config_file_path }}"
           ls -al ${{ runner.temp }}/${{ inputs.docker_bake_targets}}
+          echo "show: ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json"
           cat ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
 
       -

--- a/.github/workflows/docker-buildx-bake-hubdocker-latest.yml
+++ b/.github/workflows/docker-buildx-bake-hubdocker-latest.yml
@@ -159,7 +159,7 @@ jobs:
       -
         name: Build
         id: bake
-        uses: docker/bake-action@v5
+        uses: docker/bake-action@v6
         timeout-minutes: ${{ inputs.docker-build-timeout-minutes }} # default 360
         with:
           files: |

--- a/.github/workflows/docker-buildx-bake-hubdocker-latest.yml
+++ b/.github/workflows/docker-buildx-bake-hubdocker-latest.yml
@@ -117,7 +117,7 @@ jobs:
         name: Rename meta bake definition file
         run: |
           mkdir -p "${{ runner.temp }}/${{ inputs.docker_bake_targets}}"
-          mv "${{ steps.meta.outputs.bake-file }}" "${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json"
+          mv "${{ steps.meta.outputs.bake-file }}" "cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json"
 
       -
         name: Upload meta bake definition
@@ -125,7 +125,7 @@ jobs:
         if: ${{ inputs.push_remote_flag }}
         with:
           name: bake-latest-meta-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.docker_bake_targets }}-${{ env.PLATFORM_PAIR }}
-          path: ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
+          path: cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
           overwrite: true
           if-no-files-found: error
           retention-days: 1
@@ -154,8 +154,8 @@ jobs:
         run: |
           echo "docker_bake_config_file_path: cwd://${{ inputs.docker_bake_config_file_path }}"
           ls -al ${{ runner.temp }}/${{ inputs.docker_bake_targets}}
-          echo "show: ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json"
-          cat ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
+          echo "show: cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json"
+          cat cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
 
       -
         name: Build
@@ -165,7 +165,7 @@ jobs:
         with:
           files: |
             cwd://${{ inputs.docker_bake_config_file_path }}
-            ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
+            cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
           targets: ${{ inputs.docker_bake_targets }}
           no-cache: ${{ inputs.docker-build-no-cache }}
           provenance: false
@@ -263,10 +263,10 @@ jobs:
         name: Create manifest list and push
         working-directory: ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/digests/
         run: |
-          docker buildx imagetools create $(jq -cr '.target."docker-metadata-action".tags | map(select(startswith("${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}")) | "-t " + .) | join(" ")' ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json) \
+          docker buildx imagetools create $(jq -cr '.target."docker-metadata-action".tags | map(select(startswith("${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}")) | "-t " + .) | join(" ")' cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json) \
             $(printf '${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}@sha256:%s ' *)
       -
         name: Inspect image
         run: |
-          tag=$(jq -r '.target."docker-metadata-action".args.DOCKER_META_VERSION' ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json)
+          tag=$(jq -r '.target."docker-metadata-action".args.DOCKER_META_VERSION' cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json)
           docker buildx imagetools inspect ${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}:${tag}

--- a/.github/workflows/docker-buildx-bake-hubdocker-tag.yml
+++ b/.github/workflows/docker-buildx-bake-hubdocker-tag.yml
@@ -151,7 +151,7 @@ jobs:
       -
         name: check build files
         run: |
-          echo "docker_bake_config_file_path: ${{ inputs.docker_bake_config_file_path }}"
+          echo "docker_bake_config_file_path: cwd://${{ inputs.docker_bake_config_file_path }}"
           ls -al ${{ runner.temp }}/${{ inputs.docker_bake_targets}}
           echo "show: ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json"
           cat ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
@@ -163,7 +163,7 @@ jobs:
         timeout-minutes: ${{ inputs.docker-build-timeout-minutes }} # default 360
         with:
           files: |
-            ${{ inputs.docker_bake_config_file_path }}
+            cwd://${{ inputs.docker_bake_config_file_path }}
             ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
           targets: ${{ inputs.docker_bake_targets }}
           no-cache: ${{ inputs.docker-build-no-cache }}

--- a/.github/workflows/docker-buildx-bake-hubdocker-tag.yml
+++ b/.github/workflows/docker-buildx-bake-hubdocker-tag.yml
@@ -116,7 +116,7 @@ jobs:
         name: Rename meta bake definition file
         run: |
           mkdir -p "${{ runner.temp }}/${{ inputs.docker_bake_targets}}"
-          mv "${{ steps.meta.outputs.bake-file }}" "cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json"
+          mv "${{ steps.meta.outputs.bake-file }}" "${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json"
 
       -
         name: Upload meta bake definition
@@ -124,7 +124,7 @@ jobs:
         if: ${{ inputs.push_remote_flag }}
         with:
           name: bake-tag-meta-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.docker_bake_targets }}-${{ env.PLATFORM_PAIR }}
-          path: cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
+          path: ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
           overwrite: true
           if-no-files-found: error
           retention-days: 1
@@ -151,10 +151,10 @@ jobs:
       -
         name: check build files
         run: |
-          echo "docker_bake_config_file_path: cwd://${{ inputs.docker_bake_config_file_path }}"
+          echo "docker_bake_config_file_path: ${{ inputs.docker_bake_config_file_path }}"
           ls -al ${{ runner.temp }}/${{ inputs.docker_bake_targets}}
-          echo "show: cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json"
-          cat cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
+          echo "show: ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json"
+          cat ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
 
       -
         name: Build
@@ -262,10 +262,10 @@ jobs:
         name: Create manifest list and push
         working-directory: ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/digests/
         run: |
-          docker buildx imagetools create $(jq -cr '.target."docker-metadata-action".tags | map(select(startswith("${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}")) | "-t " + .) | join(" ")' cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json) \
+          docker buildx imagetools create $(jq -cr '.target."docker-metadata-action".tags | map(select(startswith("${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}")) | "-t " + .) | join(" ")' ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json) \
             $(printf '${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}@sha256:%s ' *)
       -
         name: Inspect image
         run: |
-          tag=$(jq -r '.target."docker-metadata-action".args.DOCKER_META_VERSION' cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json)
+          tag=$(jq -r '.target."docker-metadata-action".args.DOCKER_META_VERSION' ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json)
           docker buildx imagetools inspect ${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}:${tag}

--- a/.github/workflows/docker-buildx-bake-hubdocker-tag.yml
+++ b/.github/workflows/docker-buildx-bake-hubdocker-tag.yml
@@ -153,6 +153,7 @@ jobs:
         run: |
           echo "docker_bake_config_file_path: ${{ inputs.docker_bake_config_file_path }}"
           ls -al ${{ runner.temp }}/${{ inputs.docker_bake_targets}}
+          echo "show: ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json"
           cat ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
 
       -

--- a/.github/workflows/docker-buildx-bake-hubdocker-tag.yml
+++ b/.github/workflows/docker-buildx-bake-hubdocker-tag.yml
@@ -158,7 +158,7 @@ jobs:
       -
         name: Build
         id: bake
-        uses: docker/bake-action@v5
+        uses: docker/bake-action@v6
         timeout-minutes: ${{ inputs.docker-build-timeout-minutes }} # default 360
         with:
           files: |

--- a/.github/workflows/docker-buildx-bake-hubdocker-tag.yml
+++ b/.github/workflows/docker-buildx-bake-hubdocker-tag.yml
@@ -116,7 +116,7 @@ jobs:
         name: Rename meta bake definition file
         run: |
           mkdir -p "${{ runner.temp }}/${{ inputs.docker_bake_targets}}"
-          mv "${{ steps.meta.outputs.bake-file }}" "${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json"
+          mv "${{ steps.meta.outputs.bake-file }}" "cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json"
 
       -
         name: Upload meta bake definition
@@ -124,7 +124,7 @@ jobs:
         if: ${{ inputs.push_remote_flag }}
         with:
           name: bake-tag-meta-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.docker_bake_targets }}-${{ env.PLATFORM_PAIR }}
-          path: ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
+          path: cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
           overwrite: true
           if-no-files-found: error
           retention-days: 1
@@ -153,8 +153,8 @@ jobs:
         run: |
           echo "docker_bake_config_file_path: cwd://${{ inputs.docker_bake_config_file_path }}"
           ls -al ${{ runner.temp }}/${{ inputs.docker_bake_targets}}
-          echo "show: ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json"
-          cat ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
+          echo "show: cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json"
+          cat cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
 
       -
         name: Build
@@ -164,7 +164,7 @@ jobs:
         with:
           files: |
             cwd://${{ inputs.docker_bake_config_file_path }}
-            ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
+            cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
           targets: ${{ inputs.docker_bake_targets }}
           no-cache: ${{ inputs.docker-build-no-cache }}
           provenance: false
@@ -262,10 +262,10 @@ jobs:
         name: Create manifest list and push
         working-directory: ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/digests/
         run: |
-          docker buildx imagetools create $(jq -cr '.target."docker-metadata-action".tags | map(select(startswith("${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}")) | "-t " + .) | join(" ")' ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json) \
+          docker buildx imagetools create $(jq -cr '.target."docker-metadata-action".tags | map(select(startswith("${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}")) | "-t " + .) | join(" ")' cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json) \
             $(printf '${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}@sha256:%s ' *)
       -
         name: Inspect image
         run: |
-          tag=$(jq -r '.target."docker-metadata-action".args.DOCKER_META_VERSION' ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json)
+          tag=$(jq -r '.target."docker-metadata-action".args.DOCKER_META_VERSION' cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json)
           docker buildx imagetools inspect ${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}:${tag}

--- a/.github/workflows/docker-buildx-bake-multi-latest.yml
+++ b/.github/workflows/docker-buildx-bake-multi-latest.yml
@@ -167,7 +167,7 @@ jobs:
       -
         name: check build files
         run: |
-          echo "docker_bake_config_file_path: ${{ inputs.docker_bake_config_file_path }}"
+          echo "docker_bake_config_file_path: cwd://${{ inputs.docker_bake_config_file_path }}"
           ls -al ${{ runner.temp }}/${{ inputs.docker_bake_targets}}
           echo "show: ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json"
           cat ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
@@ -179,7 +179,7 @@ jobs:
         timeout-minutes: ${{ inputs.docker-build-timeout-minutes }} # default 360
         with:
           files: |
-            ${{ inputs.docker_bake_config_file_path }}
+            cwd://${{ inputs.docker_bake_config_file_path }}
             ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
           targets: ${{ inputs.docker_bake_targets }}
           no-cache: ${{ inputs.docker-build-no-cache }}

--- a/.github/workflows/docker-buildx-bake-multi-latest.yml
+++ b/.github/workflows/docker-buildx-bake-multi-latest.yml
@@ -169,6 +169,7 @@ jobs:
         run: |
           echo "docker_bake_config_file_path: ${{ inputs.docker_bake_config_file_path }}"
           ls -al ${{ runner.temp }}/${{ inputs.docker_bake_targets}}
+          echo "show: ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json"
           cat ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
 
       -

--- a/.github/workflows/docker-buildx-bake-multi-latest.yml
+++ b/.github/workflows/docker-buildx-bake-multi-latest.yml
@@ -123,7 +123,7 @@ jobs:
         name: Rename meta bake definition file
         run: |
           mkdir -p "${{ runner.temp }}/${{ inputs.docker_bake_targets}}"
-          mv "${{ steps.meta.outputs.bake-file }}" "cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json"
+          mv "${{ steps.meta.outputs.bake-file }}" "${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json"
 
       -
         name: Upload meta bake definition
@@ -131,7 +131,7 @@ jobs:
         if: ${{ inputs.push_remote_flag }}
         with:
           name: bake-latest-meta-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.docker_bake_targets }}-${{ env.PLATFORM_PAIR }}
-          path: cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
+          path: ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
           overwrite: true
           if-no-files-found: error
           retention-days: 1
@@ -167,10 +167,10 @@ jobs:
       -
         name: check build files
         run: |
-          echo "docker_bake_config_file_path: cwd://${{ inputs.docker_bake_config_file_path }}"
+          echo "docker_bake_config_file_path: ${{ inputs.docker_bake_config_file_path }}"
           ls -al ${{ runner.temp }}/${{ inputs.docker_bake_targets}}
-          echo "show: cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json"
-          cat cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
+          echo "show: ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json"
+          cat ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
 
       -
         name: Build
@@ -286,13 +286,13 @@ jobs:
         name: Create manifest list and push
         working-directory: ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/digests/
         run: |
-          docker buildx imagetools create $(jq -cr '.target."docker-metadata-action".tags | map(select(startswith("${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}")) | "-t " + .) | join(" ")' cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json) \
+          docker buildx imagetools create $(jq -cr '.target."docker-metadata-action".tags | map(select(startswith("${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}")) | "-t " + .) | join(" ")' ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json) \
             $(printf '${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}@sha256:%s ' *)
-          docker buildx imagetools create $(jq -cr '.target."docker-metadata-action".tags | map(select(startswith("ghcr.io/${{ inputs.ghcr_package_owner_name }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}")) | "-t " + .) | join(" ")' cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json) \
+          docker buildx imagetools create $(jq -cr '.target."docker-metadata-action".tags | map(select(startswith("ghcr.io/${{ inputs.ghcr_package_owner_name }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}")) | "-t " + .) | join(" ")' ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json) \
             $(printf 'ghcr.io/${{ inputs.ghcr_package_owner_name }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}@sha256:%s ' *)
       -
         name: Inspect image
         run: |
-          tag=$(jq -r '.target."docker-metadata-action".args.DOCKER_META_VERSION' cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json)
+          tag=$(jq -r '.target."docker-metadata-action".args.DOCKER_META_VERSION' ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json)
           docker buildx imagetools inspect ${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}:${tag}
           docker buildx imagetools inspect ghcr.io/${{ inputs.ghcr_package_owner_name }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}:${tag}

--- a/.github/workflows/docker-buildx-bake-multi-latest.yml
+++ b/.github/workflows/docker-buildx-bake-multi-latest.yml
@@ -123,7 +123,7 @@ jobs:
         name: Rename meta bake definition file
         run: |
           mkdir -p "${{ runner.temp }}/${{ inputs.docker_bake_targets}}"
-          mv "${{ steps.meta.outputs.bake-file }}" "${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json"
+          mv "${{ steps.meta.outputs.bake-file }}" "cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json"
 
       -
         name: Upload meta bake definition
@@ -131,7 +131,7 @@ jobs:
         if: ${{ inputs.push_remote_flag }}
         with:
           name: bake-latest-meta-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.docker_bake_targets }}-${{ env.PLATFORM_PAIR }}
-          path: ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
+          path: cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
           overwrite: true
           if-no-files-found: error
           retention-days: 1
@@ -169,8 +169,8 @@ jobs:
         run: |
           echo "docker_bake_config_file_path: cwd://${{ inputs.docker_bake_config_file_path }}"
           ls -al ${{ runner.temp }}/${{ inputs.docker_bake_targets}}
-          echo "show: ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json"
-          cat ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
+          echo "show: cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json"
+          cat cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
 
       -
         name: Build
@@ -180,7 +180,7 @@ jobs:
         with:
           files: |
             cwd://${{ inputs.docker_bake_config_file_path }}
-            ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
+            cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
           targets: ${{ inputs.docker_bake_targets }}
           no-cache: ${{ inputs.docker-build-no-cache }}
           provenance: false
@@ -286,13 +286,13 @@ jobs:
         name: Create manifest list and push
         working-directory: ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/digests/
         run: |
-          docker buildx imagetools create $(jq -cr '.target."docker-metadata-action".tags | map(select(startswith("${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}")) | "-t " + .) | join(" ")' ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json) \
+          docker buildx imagetools create $(jq -cr '.target."docker-metadata-action".tags | map(select(startswith("${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}")) | "-t " + .) | join(" ")' cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json) \
             $(printf '${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}@sha256:%s ' *)
-          docker buildx imagetools create $(jq -cr '.target."docker-metadata-action".tags | map(select(startswith("ghcr.io/${{ inputs.ghcr_package_owner_name }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}")) | "-t " + .) | join(" ")' ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json) \
+          docker buildx imagetools create $(jq -cr '.target."docker-metadata-action".tags | map(select(startswith("ghcr.io/${{ inputs.ghcr_package_owner_name }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}")) | "-t " + .) | join(" ")' cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json) \
             $(printf 'ghcr.io/${{ inputs.ghcr_package_owner_name }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}@sha256:%s ' *)
       -
         name: Inspect image
         run: |
-          tag=$(jq -r '.target."docker-metadata-action".args.DOCKER_META_VERSION' ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json)
+          tag=$(jq -r '.target."docker-metadata-action".args.DOCKER_META_VERSION' cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json)
           docker buildx imagetools inspect ${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}:${tag}
           docker buildx imagetools inspect ghcr.io/${{ inputs.ghcr_package_owner_name }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}:${tag}

--- a/.github/workflows/docker-buildx-bake-multi-latest.yml
+++ b/.github/workflows/docker-buildx-bake-multi-latest.yml
@@ -174,7 +174,7 @@ jobs:
       -
         name: Build
         id: bake
-        uses: docker/bake-action@v5
+        uses: docker/bake-action@v6
         timeout-minutes: ${{ inputs.docker-build-timeout-minutes }} # default 360
         with:
           files: |

--- a/.github/workflows/docker-buildx-bake-multi-tag.yml
+++ b/.github/workflows/docker-buildx-bake-multi-tag.yml
@@ -172,7 +172,7 @@ jobs:
       -
         name: Build
         id: bake
-        uses: docker/bake-action@v5
+        uses: docker/bake-action@v6
         timeout-minutes: ${{ inputs.docker-build-timeout-minutes }} # default 360
         with:
           files: |

--- a/.github/workflows/docker-buildx-bake-multi-tag.yml
+++ b/.github/workflows/docker-buildx-bake-multi-tag.yml
@@ -167,6 +167,7 @@ jobs:
         run: |
           echo "docker_bake_config_file_path: ${{ inputs.docker_bake_config_file_path }}"
           ls -al ${{ runner.temp }}/${{ inputs.docker_bake_targets}}
+          echo "show: ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json"
           cat ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
 
       -

--- a/.github/workflows/docker-buildx-bake-multi-tag.yml
+++ b/.github/workflows/docker-buildx-bake-multi-tag.yml
@@ -121,7 +121,7 @@ jobs:
         name: Rename meta bake definition file
         run: |
           mkdir -p "${{ runner.temp }}/${{ inputs.docker_bake_targets}}"
-          mv "${{ steps.meta.outputs.bake-file }}" "${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json"
+          mv "${{ steps.meta.outputs.bake-file }}" "cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json"
 
       -
         name: Upload meta bake definition
@@ -129,7 +129,7 @@ jobs:
         if: ${{ inputs.push_remote_flag }}
         with:
           name: bake-tag-meta-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.docker_bake_targets }}-${{ env.PLATFORM_PAIR }}
-          path: ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
+          path: cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
           overwrite: true
           if-no-files-found: error
           retention-days: 1
@@ -167,8 +167,8 @@ jobs:
         run: |
           echo "docker_bake_config_file_path: cwd://${{ inputs.docker_bake_config_file_path }}"
           ls -al ${{ runner.temp }}/${{ inputs.docker_bake_targets}}
-          echo "show: ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json"
-          cat ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
+          echo "show: cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json"
+          cat cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
 
       -
         name: Build
@@ -178,7 +178,7 @@ jobs:
         with:
           files: |
             cwd://${{ inputs.docker_bake_config_file_path }}
-            ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
+            cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
           targets: ${{ inputs.docker_bake_targets }}
           no-cache: ${{ inputs.docker-build-no-cache }}
           provenance: false
@@ -284,13 +284,13 @@ jobs:
         name: Create manifest list and push
         working-directory: ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/digests/
         run: |
-          docker buildx imagetools create $(jq -cr '.target."docker-metadata-action".tags | map(select(startswith("${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}")) | "-t " + .) | join(" ")' ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json) \
+          docker buildx imagetools create $(jq -cr '.target."docker-metadata-action".tags | map(select(startswith("${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}")) | "-t " + .) | join(" ")' cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json) \
             $(printf '${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}@sha256:%s ' *)
-          docker buildx imagetools create $(jq -cr '.target."docker-metadata-action".tags | map(select(startswith("ghcr.io/${{ inputs.ghcr_package_owner_name }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}")) | "-t " + .) | join(" ")' ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json) \
+          docker buildx imagetools create $(jq -cr '.target."docker-metadata-action".tags | map(select(startswith("ghcr.io/${{ inputs.ghcr_package_owner_name }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}")) | "-t " + .) | join(" ")' cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json) \
             $(printf 'ghcr.io/${{ inputs.ghcr_package_owner_name }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}@sha256:%s ' *)
       -
         name: Inspect image
         run: |
-          tag=$(jq -r '.target."docker-metadata-action".args.DOCKER_META_VERSION' ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json)
+          tag=$(jq -r '.target."docker-metadata-action".args.DOCKER_META_VERSION' cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json)
           docker buildx imagetools inspect ${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}:${tag}
           docker buildx imagetools inspect ghcr.io/${{ inputs.ghcr_package_owner_name }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}:${tag}

--- a/.github/workflows/docker-buildx-bake-multi-tag.yml
+++ b/.github/workflows/docker-buildx-bake-multi-tag.yml
@@ -121,7 +121,7 @@ jobs:
         name: Rename meta bake definition file
         run: |
           mkdir -p "${{ runner.temp }}/${{ inputs.docker_bake_targets}}"
-          mv "${{ steps.meta.outputs.bake-file }}" "cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json"
+          mv "${{ steps.meta.outputs.bake-file }}" "${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json"
 
       -
         name: Upload meta bake definition
@@ -129,7 +129,7 @@ jobs:
         if: ${{ inputs.push_remote_flag }}
         with:
           name: bake-tag-meta-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.docker_bake_targets }}-${{ env.PLATFORM_PAIR }}
-          path: cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
+          path: ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
           overwrite: true
           if-no-files-found: error
           retention-days: 1
@@ -165,10 +165,10 @@ jobs:
       -
         name: check build files
         run: |
-          echo "docker_bake_config_file_path: cwd://${{ inputs.docker_bake_config_file_path }}"
+          echo "docker_bake_config_file_path: ${{ inputs.docker_bake_config_file_path }}"
           ls -al ${{ runner.temp }}/${{ inputs.docker_bake_targets}}
-          echo "show: cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json"
-          cat cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
+          echo "show: ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json"
+          cat ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
 
       -
         name: Build
@@ -284,13 +284,13 @@ jobs:
         name: Create manifest list and push
         working-directory: ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/digests/
         run: |
-          docker buildx imagetools create $(jq -cr '.target."docker-metadata-action".tags | map(select(startswith("${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}")) | "-t " + .) | join(" ")' cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json) \
+          docker buildx imagetools create $(jq -cr '.target."docker-metadata-action".tags | map(select(startswith("${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}")) | "-t " + .) | join(" ")' ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json) \
             $(printf '${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}@sha256:%s ' *)
-          docker buildx imagetools create $(jq -cr '.target."docker-metadata-action".tags | map(select(startswith("ghcr.io/${{ inputs.ghcr_package_owner_name }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}")) | "-t " + .) | join(" ")' cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json) \
+          docker buildx imagetools create $(jq -cr '.target."docker-metadata-action".tags | map(select(startswith("ghcr.io/${{ inputs.ghcr_package_owner_name }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}")) | "-t " + .) | join(" ")' ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json) \
             $(printf 'ghcr.io/${{ inputs.ghcr_package_owner_name }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}@sha256:%s ' *)
       -
         name: Inspect image
         run: |
-          tag=$(jq -r '.target."docker-metadata-action".args.DOCKER_META_VERSION' cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json)
+          tag=$(jq -r '.target."docker-metadata-action".args.DOCKER_META_VERSION' ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json)
           docker buildx imagetools inspect ${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}:${tag}
           docker buildx imagetools inspect ghcr.io/${{ inputs.ghcr_package_owner_name }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}:${tag}

--- a/.github/workflows/docker-buildx-bake-multi-tag.yml
+++ b/.github/workflows/docker-buildx-bake-multi-tag.yml
@@ -165,7 +165,7 @@ jobs:
       -
         name: check build files
         run: |
-          echo "docker_bake_config_file_path: ${{ inputs.docker_bake_config_file_path }}"
+          echo "docker_bake_config_file_path: cwd://${{ inputs.docker_bake_config_file_path }}"
           ls -al ${{ runner.temp }}/${{ inputs.docker_bake_targets}}
           echo "show: ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json"
           cat ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
@@ -177,7 +177,7 @@ jobs:
         timeout-minutes: ${{ inputs.docker-build-timeout-minutes }} # default 360
         with:
           files: |
-            ${{ inputs.docker_bake_config_file_path }}
+            cwd://${{ inputs.docker_bake_config_file_path }}
             ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
           targets: ${{ inputs.docker_bake_targets }}
           no-cache: ${{ inputs.docker-build-no-cache }}


### PR DESCRIPTION
[docker/bake-action/issues/287](https://github.com/docker/bake-action/issues/287)

Need to use the local bake file by specifying the `cwd://` prefix when building with a git context, otherwise it will try to look at this file within the git repo.