### PR TITLE
feat: add Docker Hub description update functionality

### DIFF
--- a/.github/workflows/deploy-tag.yml
+++ b/.github/workflows/deploy-tag.yml
@@ -29,6 +29,12 @@ on:
         required: false
         type: string
 
+      dockerhub_description_path:
+        description: 'dockerhub description update path'
+        default: 'README.md'
+        required: false
+        type: string
+
 permissions: # https://docs.github.com/actions/using-workflows/workflow-syntax-for-github-actions#permissions
   contents: write
   discussions: write
@@ -76,3 +82,12 @@ jobs:
           #   **/*.zip
           #   **/*.tar.gz
           #   **/*.sha256
+
+      - name: Docker Hub Description
+        # https://github.com/marketplace/actions/docker-hub-description
+        uses: peter-evans/dockerhub-description@v5
+        with:
+          username: ${{ vars.ENV_DOCKERHUB_OWNER }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: ${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}
+          readme-filepath: ${{ inputs.dockerhub_description_path }}

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+# template-docker-runtime-alpine
+
+- docker hub see [https://hub.docker.com/r/template-hub-user/template-docker-runtime-alpine](https://hub.docker.com/r/template-hub-user/template-docker-runtime-alpine)
+
+
 [![ci](https://github.com/bridgewwater/template-docker-runtime-alpine/actions/workflows/ci.yml/badge.svg)](https://github.com/bridgewwater/template-docker-runtime-alpine/actions/workflows/ci.yml)
 
 [![GitHub license](https://img.shields.io/github/license/bridgewwater/template-docker-runtime-alpine)](https://github.com/bridgewwater/template-docker-runtime-alpine)
@@ -8,11 +13,7 @@
 [![docker image size](https://img.shields.io/docker/image-size/template-hub-user/template-docker-runtime-alpine)](https://hub.docker.com/r/template-hub-user/template-docker-runtime-alpine)
 [![docker pulls](https://img.shields.io/docker/pulls/template-hub-user/template-docker-runtime-alpine)](https://hub.docker.com/r/template-hub-user/template-docker-runtime-alpine/tags?page=1&ordering=last_updated)
 
-# template-docker-runtime-alpine
-
-- docker hub see [https://hub.docker.com/r/template-hub-user/template-docker-runtime-alpine](https://hub.docker.com/r/template-hub-user/template-docker-runtime-alpine)
-
-## for
+## features
 
 - alpine basic build image
 
@@ -38,64 +39,3 @@ docker run --rm \
 
 [https://github.com/bridgewwater/template-docker-runtime-alpine](https://github.com/bridgewwater/template-docker-runtime-alpine)
 
-## source usage
-
-### env
-
-- parent image `alpine` version `3.20.3`
-
-### todo-list
-
-- rename `bridgewwater/template-docker-runtime-alpine` to new github url
-- rename docker hub user `template-hub-user` to new org or user
-- rename docker hub `template-docker-runtime-alpine` to new docker image name
-- rename docker repo name at `docker-bake.hcl`
-    - `template-docker-runtime-alpine` to new docker image name
-    - `image-basic-all` to change `platforms`
-    - `image-alpine-all` to change `platforms`
-
-- use github action for this workflow push to docker hub, must add
-    - variables `ENV_DOCKERHUB_OWNER` user of docker hub
-    - variables `ENV_DOCKERHUB_REPO_NAME` repo name of docker hub
-    - secrets `DOCKERHUB_TOKEN` token of docker hub user from [hub.docker](https://hub.docker.com/settings/security)
-
-- change `DOCKER_IMAGE_PLATFORMS: linux/amd64,linux/arm64/v8` to your need [docker buildx](https://docs.docker.com/buildx/working-with-buildx/)
-  - also change `jobs.docker-image-buildx.strategy.matrix.docker_image.[platform]` same as `DOCKER_IMAGE_PLATFORMS`
-- change `push_remote_flag: ${{ github.event.pull_request.merged == true }}` to let latest tag push to docker hub
-
-
-### dev mode
-
-```bash
-# see help
-$ make help
-# see or check build env
-$ make env
-
-# fast build
-$ make all
-# clean build
-$ make clean
-
-# check env
-$ make dockerEnv
-
-# change build.dockerfile
-# then test image
-$ make dockerTestRestartLatest
-# remove build image
-$ make clean
-```
-
-then change github workflows config to use
-
-## Contributing
-
-[![Contributor Covenant](https://img.shields.io/badge/contributor%20covenant-v1.4-ff69b4.svg)](.github/CONTRIBUTING_DOC/CODE_OF_CONDUCT.md)
-[![GitHub contributors](https://img.shields.io/github/contributors/bridgewwater/template-docker-runtime-alpine)](https://github.com/bridgewwater/template-docker-runtime-alpine/graphs/contributors)
-
-We welcome community contributions to this project.
-
-Please read [Contributor Guide](.github/CONTRIBUTING_DOC/CONTRIBUTING.md) for more information on how to get started.
-
-请阅读有关 [贡献者指南](.github/CONTRIBUTING_DOC/zh-CN/CONTRIBUTING.md) 以获取更多如何入门的信息

--- a/doc-dev/dev.md
+++ b/doc-dev/dev.md
@@ -1,0 +1,50 @@
+## source usage
+
+### env
+
+- parent image `alpine` version `3.20.3`
+
+### todo-list
+
+- rename `bridgewwater/template-docker-runtime-alpine` to new github url
+- rename docker hub user `template-hub-user` to new org or user
+- rename docker hub `template-docker-runtime-alpine` to new docker image name
+- rename docker repo name at `docker-bake.hcl`
+    - `template-docker-runtime-alpine` to new docker image name
+    - `image-basic-all` to change `platforms`
+    - `image-alpine-all` to change `platforms`
+
+- use github action for this workflow push to docker hub, must add
+    - variables `ENV_DOCKERHUB_OWNER` user of docker hub
+    - variables `ENV_DOCKERHUB_REPO_NAME` repo name of docker hub
+    - secrets `DOCKERHUB_TOKEN` token of docker hub user from [hub.docker](https://hub.docker.com/settings/security)
+
+- change `DOCKER_IMAGE_PLATFORMS: linux/amd64,linux/arm64/v8` to your need [docker buildx](https://docs.docker.com/buildx/working-with-buildx/)
+  - also change `jobs.docker-image-buildx.strategy.matrix.docker_image.[platform]` same as `DOCKER_IMAGE_PLATFORMS`
+- change `push_remote_flag: ${{ github.event.pull_request.merged == true }}` to let latest tag push to docker hub
+
+
+### dev mode
+
+```bash
+# see help
+$ make help
+# see or check build env
+$ make env
+
+# fast build
+$ make all
+# clean build
+$ make clean
+
+# check env
+$ make dockerEnv
+
+# change build.dockerfile
+# then test image
+$ make dockerTestRestartLatest
+# remove build image
+$ make clean
+```
+
+then change github workflows config to use


### PR DESCRIPTION
- Introduced a new input parameter `dockerhub_description_path` in the deploy-tag workflow to specify the path for the Docker Hub description update.
- Added a new step to the workflow that utilizes the `dockerhub-description` action to update the Docker Hub repository description using the specified README file.
- Created a new `dev.md` file to document source usage, environment setup, and a todo list for future improvements.