### PR TITLE
feat: update meta bake definition file handling

### DIFF
--- a/.github/workflows-template/docker-buildx-bake/docker-buildx-bake-hubdocker-latest.yml
+++ b/.github/workflows-template/docker-buildx-bake/docker-buildx-bake-hubdocker-latest.yml
@@ -117,7 +117,17 @@ jobs:
         name: Rename meta bake definition file
         run: |
           mkdir -p "${{ runner.temp }}/${{ inputs.docker_bake_targets}}"
-          mv "${{ steps.meta.outputs.bake-file }}" "${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json"
+          jq '
+            def scrub:
+              if type == "object" then
+                with_entries(select(.key != "buildx.build.provenance") | .value |= scrub)
+              elif type == "array" then
+                map(scrub)
+              else
+                .
+              end;
+            scrub
+          ' "${{ steps.meta.outputs.bake-file }}" > "${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json"
 
       -
         name: Upload meta bake definition

--- a/.github/workflows-template/docker-buildx-bake/docker-buildx-bake-hubdocker-tag.yml
+++ b/.github/workflows-template/docker-buildx-bake/docker-buildx-bake-hubdocker-tag.yml
@@ -116,7 +116,17 @@ jobs:
         name: Rename meta bake definition file
         run: |
           mkdir -p "${{ runner.temp }}/${{ inputs.docker_bake_targets}}"
-          mv "${{ steps.meta.outputs.bake-file }}" "${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json"
+          jq '
+            def scrub:
+              if type == "object" then
+                with_entries(select(.key != "buildx.build.provenance") | .value |= scrub)
+              elif type == "array" then
+                map(scrub)
+              else
+                .
+              end;
+            scrub
+          ' "${{ steps.meta.outputs.bake-file }}" > "${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json"
 
       -
         name: Upload meta bake definition

--- a/.github/workflows-template/docker-buildx-bake/docker-buildx-bake-multi-latest.yml
+++ b/.github/workflows-template/docker-buildx-bake/docker-buildx-bake-multi-latest.yml
@@ -123,7 +123,17 @@ jobs:
         name: Rename meta bake definition file
         run: |
           mkdir -p "${{ runner.temp }}/${{ inputs.docker_bake_targets}}"
-          mv "${{ steps.meta.outputs.bake-file }}" "${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json"
+          jq '
+            def scrub:
+              if type == "object" then
+                with_entries(select(.key != "buildx.build.provenance") | .value |= scrub)
+              elif type == "array" then
+                map(scrub)
+              else
+                .
+              end;
+            scrub
+          ' "${{ steps.meta.outputs.bake-file }}" > "${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json"
 
       -
         name: Upload meta bake definition

--- a/.github/workflows-template/docker-buildx-bake/docker-buildx-bake-multi-tag.yml
+++ b/.github/workflows-template/docker-buildx-bake/docker-buildx-bake-multi-tag.yml
@@ -121,7 +121,17 @@ jobs:
         name: Rename meta bake definition file
         run: |
           mkdir -p "${{ runner.temp }}/${{ inputs.docker_bake_targets}}"
-          mv "${{ steps.meta.outputs.bake-file }}" "${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json"
+          jq '
+            def scrub:
+              if type == "object" then
+                with_entries(select(.key != "buildx.build.provenance") | .value |= scrub)
+              elif type == "array" then
+                map(scrub)
+              else
+                .
+              end;
+            scrub
+          ' "${{ steps.meta.outputs.bake-file }}" > "${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json"
 
       -
         name: Upload meta bake definition

--- a/.github/workflows/docker-buildx-bake-hubdocker-latest.yml
+++ b/.github/workflows/docker-buildx-bake-hubdocker-latest.yml
@@ -117,7 +117,17 @@ jobs:
         name: Rename meta bake definition file
         run: |
           mkdir -p "${{ runner.temp }}/${{ inputs.docker_bake_targets}}"
-          mv "${{ steps.meta.outputs.bake-file }}" "${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json"
+          jq '
+            def scrub:
+              if type == "object" then
+                with_entries(select(.key != "buildx.build.provenance") | .value |= scrub)
+              elif type == "array" then
+                map(scrub)
+              else
+                .
+              end;
+            scrub
+          ' "${{ steps.meta.outputs.bake-file }}" > "${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json"
 
       -
         name: Upload meta bake definition

--- a/.github/workflows/docker-buildx-bake-hubdocker-tag.yml
+++ b/.github/workflows/docker-buildx-bake-hubdocker-tag.yml
@@ -116,7 +116,17 @@ jobs:
         name: Rename meta bake definition file
         run: |
           mkdir -p "${{ runner.temp }}/${{ inputs.docker_bake_targets}}"
-          mv "${{ steps.meta.outputs.bake-file }}" "${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json"
+          jq '
+            def scrub:
+              if type == "object" then
+                with_entries(select(.key != "buildx.build.provenance") | .value |= scrub)
+              elif type == "array" then
+                map(scrub)
+              else
+                .
+              end;
+            scrub
+          ' "${{ steps.meta.outputs.bake-file }}" > "${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json"
 
       -
         name: Upload meta bake definition

--- a/.github/workflows/docker-buildx-bake-multi-latest.yml
+++ b/.github/workflows/docker-buildx-bake-multi-latest.yml
@@ -123,7 +123,17 @@ jobs:
         name: Rename meta bake definition file
         run: |
           mkdir -p "${{ runner.temp }}/${{ inputs.docker_bake_targets}}"
-          mv "${{ steps.meta.outputs.bake-file }}" "${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json"
+          jq '
+            def scrub:
+              if type == "object" then
+                with_entries(select(.key != "buildx.build.provenance") | .value |= scrub)
+              elif type == "array" then
+                map(scrub)
+              else
+                .
+              end;
+            scrub
+          ' "${{ steps.meta.outputs.bake-file }}" > "${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json"
 
       -
         name: Upload meta bake definition

--- a/.github/workflows/docker-buildx-bake-multi-tag.yml
+++ b/.github/workflows/docker-buildx-bake-multi-tag.yml
@@ -121,7 +121,17 @@ jobs:
         name: Rename meta bake definition file
         run: |
           mkdir -p "${{ runner.temp }}/${{ inputs.docker_bake_targets}}"
-          mv "${{ steps.meta.outputs.bake-file }}" "${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json"
+          jq '
+            def scrub:
+              if type == "object" then
+                with_entries(select(.key != "buildx.build.provenance") | .value |= scrub)
+              elif type == "array" then
+                map(scrub)
+              else
+                .
+              end;
+            scrub
+          ' "${{ steps.meta.outputs.bake-file }}" > "${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json"
 
       -
         name: Upload meta bake definition


### PR DESCRIPTION
- Refactored the process of renaming the meta bake definition file to utilize `jq` for scrubbing the `buildx.build.provenance` key from the JSON output. This change enhances the clarity of the generated bake meta file by removing unnecessary provenance data.
- The updates were made across multiple workflow files to ensure consistency in handling the bake meta definitions.

### Related Issues

List related issues here

- #43