### PR TITLE
52 bug ci step extract container image digest from bake output

### DIFF
--- a/.github/workflows/docker-buildx-bake-hubdocker-latest.yml
+++ b/.github/workflows/docker-buildx-bake-hubdocker-latest.yml
@@ -190,8 +190,15 @@ jobs:
 
       - name: Extract container image digest from bake output
         id: bake-output-container-image-digest
+        env:
+          BAKE_METADATA: ${{ steps.bake.outputs.metadata }}
         run: |
-          echo "digest=$(echo '${{ steps.bake.outputs.metadata}}' | jq -cr '.["${{ inputs.docker_bake_targets }}"]["containerimage.digest"]')" >>$GITHUB_OUTPUT
+          digest="$(jq -cr --arg target "${{ inputs.docker_bake_targets }}" '.[$target]["containerimage.digest"] // empty' <<<"$BAKE_METADATA")"
+          if [ -z "$digest" ] || [ "$digest" = "null" ]; then
+            echo "failed to extract container image digest from bake output metadata"
+            exit 1
+          fi
+          echo "digest=$digest" >>$GITHUB_OUTPUT
 
       -
         name: Export digest

--- a/.github/workflows/docker-buildx-bake-hubdocker-latest.yml
+++ b/.github/workflows/docker-buildx-bake-hubdocker-latest.yml
@@ -74,7 +74,7 @@ jobs:
         name: Create matrix
         id: platforms
         run: |
-          echo "matrix=$(docker buildx bake ${{ inputs.docker_bake_targets }}${{inputs.docker_bake_matrix_target_postfix}} --print | jq -cr '.target."${{ inputs.docker_bake_targets }}${{inputs.docker_bake_matrix_target_postfix}}".platforms')" >>${GITHUB_OUTPUT}
+          echo "matrix=$(docker buildx bake ${{ inputs.docker_bake_targets }}${{ inputs.docker_bake_matrix_target_postfix }} --print | jq -cr '.target."${{ inputs.docker_bake_targets }}${{ inputs.docker_bake_matrix_target_postfix }}".platforms')" >>${GITHUB_OUTPUT}
       -
         name: Show matrix
         run: |
@@ -175,7 +175,7 @@ jobs:
         with:
           files: |
             cwd://${{ inputs.docker_bake_config_file_path }}
-            cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
+            cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets }}/bake-meta.json
           targets: ${{ inputs.docker_bake_targets }}
           no-cache: ${{ inputs.docker-build-no-cache }}
           provenance: false
@@ -203,10 +203,10 @@ jobs:
       -
         name: Export digest
         run: |
-          mkdir -p ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/digests
+          mkdir -p ${{ runner.temp }}/${{ inputs.docker_bake_targets }}/digests
           digest="${{ steps.bake-output-container-image-digest.outputs.digest }}"
-          touch "${{ runner.temp }}/${{ inputs.docker_bake_targets}}/digests/${digest#sha256:}"
-          ls -al ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/digests
+          touch "${{ runner.temp }}/${{ inputs.docker_bake_targets }}/digests/${digest#sha256:}"
+          ls -al ${{ runner.temp }}/${{ inputs.docker_bake_targets }}/digests
 
       -
         name: Upload digest
@@ -256,14 +256,14 @@ jobs:
           # name: digests
           ## https://github.com/actions/download-artifact/tree/v4?tab=readme-ov-file#breaking-changes
           pattern: digests-latest-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.docker_bake_targets }}-*
-          path: ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/digests/
+          path: ${{ runner.temp }}/${{ inputs.docker_bake_targets }}/digests/
           merge-multiple: true
 
       -
         name: check temp config files
         run: |
-          ls -al ${{ runner.temp }}/${{ inputs.docker_bake_targets}}
-          ls -al ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/digests/
+          ls -al ${{ runner.temp }}/${{ inputs.docker_bake_targets }}
+          ls -al ${{ runner.temp }}/${{ inputs.docker_bake_targets }}/digests/
 
       -
         name: Set up Docker Buildx
@@ -285,5 +285,5 @@ jobs:
       -
         name: Inspect image
         run: |
-          tag=$(jq -r '.target."docker-metadata-action".args.DOCKER_META_VERSION' ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json)
+          tag=$(jq -r '.target."docker-metadata-action".args.DOCKER_META_VERSION' ${{ runner.temp }}/${{ inputs.docker_bake_targets }}/bake-meta.json)
           docker buildx imagetools inspect ${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}:${tag}

--- a/.github/workflows/docker-buildx-bake-hubdocker-tag.yml
+++ b/.github/workflows/docker-buildx-bake-hubdocker-tag.yml
@@ -189,8 +189,15 @@ jobs:
 
       - name: Extract container image digest from bake output
         id: bake-output-container-image-digest
+        env:
+          BAKE_METADATA: ${{ steps.bake.outputs.metadata }}
         run: |
-          echo "digest=$(echo '${{ steps.bake.outputs.metadata}}' | jq -cr '.["${{ inputs.docker_bake_targets }}"]["containerimage.digest"]')" >>$GITHUB_OUTPUT
+          digest="$(jq -cr --arg target "${{ inputs.docker_bake_targets }}" '.[$target]["containerimage.digest"] // empty' <<<"$BAKE_METADATA")"
+          if [ -z "$digest" ] || [ "$digest" = "null" ]; then
+            echo "failed to extract container image digest from bake output metadata"
+            exit 1
+          fi
+          echo "digest=$digest" >>$GITHUB_OUTPUT
 
       -
         name: Export digest

--- a/.github/workflows/docker-buildx-bake-hubdocker-tag.yml
+++ b/.github/workflows/docker-buildx-bake-hubdocker-tag.yml
@@ -73,7 +73,7 @@ jobs:
         name: Create matrix
         id: platforms
         run: |
-          echo "matrix=$(docker buildx bake ${{ inputs.docker_bake_targets }}${{inputs.docker_bake_matrix_target_postfix}} --print | jq -cr '.target."${{ inputs.docker_bake_targets }}${{inputs.docker_bake_matrix_target_postfix}}".platforms')" >>${GITHUB_OUTPUT}
+          echo "matrix=$(docker buildx bake ${{ inputs.docker_bake_targets }}${{ inputs.docker_bake_matrix_target_postfix }} --print | jq -cr '.target."${{ inputs.docker_bake_targets }}${{ inputs.docker_bake_matrix_target_postfix }}".platforms')" >>${GITHUB_OUTPUT}
       -
         name: Show matrix
         run: |
@@ -107,7 +107,7 @@ jobs:
             ${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}
           tags: |
             # type semver https://github.com/docker/metadata-action#typesemver
-            type=semver,pattern={{version}}
+            type=semver,pattern={{ version }}
           flavor: |
             latest=auto
             suffix=${{ inputs.docker-metadata-flavor-suffix }}
@@ -134,7 +134,7 @@ jobs:
         if: ${{ inputs.push_remote_flag }}
         with:
           name: bake-tag-meta-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.docker_bake_targets }}-${{ env.PLATFORM_PAIR }}
-          path: ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
+          path: ${{ runner.temp }}/${{ inputs.docker_bake_targets }}/bake-meta.json
           overwrite: true
           if-no-files-found: error
           retention-days: 1
@@ -163,8 +163,8 @@ jobs:
         run: |
           echo "docker_bake_config_file_path: ${{ inputs.docker_bake_config_file_path }}"
           ls -al ${{ runner.temp }}/${{ inputs.docker_bake_targets}}
-          echo "show: ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json"
-          cat ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
+          echo "show: ${{ runner.temp }}/${{ inputs.docker_bake_targets }}/bake-meta.json"
+          cat ${{ runner.temp }}/${{ inputs.docker_bake_targets }}/bake-meta.json
 
       -
         name: Build
@@ -174,7 +174,7 @@ jobs:
         with:
           files: |
             cwd://${{ inputs.docker_bake_config_file_path }}
-            cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
+            cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets }}/bake-meta.json
           targets: ${{ inputs.docker_bake_targets }}
           no-cache: ${{ inputs.docker-build-no-cache }}
           provenance: false
@@ -202,10 +202,10 @@ jobs:
       -
         name: Export digest
         run: |
-          mkdir -p ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/digests
+          mkdir -p ${{ runner.temp }}/${{ inputs.docker_bake_targets }}/digests
           digest="${{ steps.bake-output-container-image-digest.outputs.digest }}"
-          touch "${{ runner.temp }}/${{ inputs.docker_bake_targets}}/digests/${digest#sha256:}"
-          ls -al ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/digests
+          touch "${{ runner.temp }}/${{ inputs.docker_bake_targets }}/digests/${digest#sha256:}"
+          ls -al ${{ runner.temp }}/${{ inputs.docker_bake_targets }}/digests
 
       -
         name: Upload digest
@@ -221,8 +221,8 @@ jobs:
       -
         name: check temp config files
         run: |
-          ls -al ${{ runner.temp }}/${{ inputs.docker_bake_targets}}
-          ls -al ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/digests/
+          ls -al ${{ runner.temp }}/${{ inputs.docker_bake_targets }}
+          ls -al ${{ runner.temp }}/${{ inputs.docker_bake_targets }}/digests/
 
 
   merge:
@@ -235,8 +235,8 @@ jobs:
       -
         name: check temp path
         run: |
-          mkdir -p ${{ runner.temp }}/${{ inputs.docker_bake_targets}}
-          ls -al ${{ runner.temp }}/${{ inputs.docker_bake_targets}}
+          mkdir -p ${{ runner.temp }}/${{ inputs.docker_bake_targets }}
+          ls -al ${{ runner.temp }}/${{ inputs.docker_bake_targets }}
 
       -
         name: Download meta bake definition
@@ -245,7 +245,7 @@ jobs:
           # name: bake-meta
           ## https://github.com/actions/download-artifact/tree/v4?tab=readme-ov-file#breaking-changes
           pattern: bake-tag-meta-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.docker_bake_targets }}-*
-          path: ${{ runner.temp }}/${{ inputs.docker_bake_targets}}
+          path: ${{ runner.temp }}/${{ inputs.docker_bake_targets }}
           merge-multiple: true
 
       -
@@ -279,10 +279,10 @@ jobs:
         name: Create manifest list and push
         working-directory: ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/digests/
         run: |
-          docker buildx imagetools create $(jq -cr '.target."docker-metadata-action".tags | map(select(startswith("${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}")) | "-t " + .) | join(" ")' ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json) \
+          docker buildx imagetools create $(jq -cr '.target."docker-metadata-action".tags | map(select(startswith("${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}")) | "-t " + .) | join(" ")' ${{ runner.temp }}/${{ inputs.docker_bake_targets }}/bake-meta.json) \
             $(printf '${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}@sha256:%s ' *)
       -
         name: Inspect image
         run: |
-          tag=$(jq -r '.target."docker-metadata-action".args.DOCKER_META_VERSION' ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json)
+          tag=$(jq -r '.target."docker-metadata-action".args.DOCKER_META_VERSION' ${{ runner.temp }}/${{ inputs.docker_bake_targets }}/bake-meta.json)
           docker buildx imagetools inspect ${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}:${tag}


### PR DESCRIPTION
### Description of Changes

- Updated the extraction logic for the container image digest to use the BAKE_METADATA environment variable, ensuring a more reliable retrieval of the digest.
- Added error handling to exit with a failure message if the digest is not found or is null, improving the robustness of the workflow.
- Adjusted spacing in echo commands to ensure consistency in the output format.
- Corrected path formatting in multiple locations to maintain uniformity across the workflows.
- Improved readability by ensuring consistent use of spaces around variables and paths.

### Related Issues

List related issues here

- #52